### PR TITLE
Implement scaling for renderer

### DIFF
--- a/common.c
+++ b/common.c
@@ -17,10 +17,13 @@ void common_init (void) {
 	SDL_Init(SDL_INIT_VIDEO);
 
 	window = SDL_CreateWindow(
-		"smallconsole", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, SCREEN_WIDTH, SCREEN_HEIGHT, 0
+		"smallconsole", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, RENDER_WIDTH, RENDER_HEIGHT, 0
 	);
 
-	renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
+	// software renderer works much faster
+	renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_SOFTWARE);
+	SDL_RenderSetLogicalSize(renderer, SCREEN_WIDTH, SCREEN_HEIGHT);
+	SDL_RenderSetScale(renderer, (float) RENDER_SCALE, (float) RENDER_SCALE);
 }
 
 void file_load_rom (const char *rom_filename) {

--- a/common.h
+++ b/common.h
@@ -16,6 +16,10 @@
 #define SCREEN_WIDTH  160
 #define SCREEN_HEIGHT 144
 
+#define RENDER_SCALE 2
+#define RENDER_WIDTH (SCREEN_WIDTH * RENDER_SCALE)
+#define RENDER_HEIGHT (SCREEN_HEIGHT * RENDER_SCALE)
+
 void common_init ();
 
 void common_shutdown ();

--- a/main.c
+++ b/main.c
@@ -11,7 +11,7 @@ int main(int argc, char *argv[]) {
 
 	println("EMULATOR INIT");
 
-	file_load_rom("11.gb");
+	file_load_rom("tetris.gb");
 
 	keyboard_set_handlers(joypad_key_down, joypad_key_up);
 	gpu_init();


### PR DESCRIPTION
Window now will be much bigger
By default scale is 2
So emulator will render 320x288 window